### PR TITLE
Not tested , 50% fix for the cheat engine issue

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -884,13 +884,15 @@ AddEventHandler('esx_vehicleshop:hasEnteredMarker', function (zone)
       end
 
       local resellPrice = math.floor(vehicleData.price / 100 * Config.ResellPercentage)
+	  local normalPrice = vehicleData.price
 
       CurrentAction     = 'resell_vehicle'
       CurrentActionMsg  = _U('sell_menu', vehicleData.name, resellPrice)
 
       CurrentActionData = {
         vehicle = vehicle,
-        price   = resellPrice
+        price   = resellPrice,
+		originalPrice = normalPrice
       }
     end
   end
@@ -1014,7 +1016,7 @@ Citizen.CreateThread(function ()
 						else
 							ESX.ShowNotification(_U('not_yours'))
 						end
-					end, GetVehicleNumberPlateText(CurrentActionData.vehicle), CurrentActionData.price)
+					end, GetVehicleNumberPlateText(CurrentActionData.vehicle), CurrentActionData.price, CurrentActionData.originalPrice)
 				elseif CurrentAction == 'boss_actions_menu' then
 					OpenBossActionsMenu()
 				end

--- a/server/main.lua
+++ b/server/main.lua
@@ -346,7 +346,7 @@ ESX.RegisterServerCallback('esx_vehicleshop:giveBackVehicle', function (source, 
 	end)
 end)
 
-ESX.RegisterServerCallback('esx_vehicleshop:resellVehicle', function (source, cb, plate, price)
+ESX.RegisterServerCallback('esx_vehicleshop:resellVehicle', function (source, cb, plate, price, oprice)
 	MySQL.Async.fetchAll('SELECT * FROM rented_vehicles WHERE plate = @plate', {
 		['@plate'] = plate
 	}, function (result)
@@ -363,7 +363,8 @@ ESX.RegisterServerCallback('esx_vehicleshop:resellVehicle', function (source, cb
 
 				-- does the owner match?
 				if result[1] ~= nil then
-					xPlayer.addMoney(price)
+					local supposesellprice = math.floor(oprice / 100 * Config.ResellPercentage)
+					xPlayer.addMoney(supposesellprice)
 					RemoveOwnedVehicle(plate)
 					cb(true)
 				else


### PR DESCRIPTION
A little trick that could work on most of the people using this cheat, instead of calculating the selling price on the spot just sending the original vehicle price for the server and then calculate it at the server
I use this to check originalSellPrice for discord notifications might as well release something that could trick them people